### PR TITLE
Add simple ingest source for websockets

### DIFF
--- a/quine-endpoints/src/main/scala/com/thatdot/quine/routes/IngestRoutes.scala
+++ b/quine-endpoints/src/main/scala/com/thatdot/quine/routes/IngestRoutes.scala
@@ -303,6 +303,23 @@ final case class SQSIngest(
   @docs("maximum records to process per second") maximumPerSecond: Option[Int]
 ) extends IngestStreamConfiguration
 
+@title("Websockets Ingest Stream (Simple Startup)")
+@unnamed
+@docs("A websocket stream started after a sequence of text messages")
+final case class WebsocketIngestSimpleStartup(
+  format: StreamedRecordFormat = IngestRoutes.defaultStreamedRecordFormat,
+  @docs("websocket (ws: or wss:) url to connect to")
+  wsUrl: String,
+  @docs("initial messages to send to the server on connecting")
+  initMessages: Seq[String] = Seq.empty,
+  @docs("maximum number of records to ingest simultaneously")
+  parallelism: Int = IngestRoutes.defaultWriteParallelism,
+  @docs(s"""text encoding used to read text messages in the stream. Only UTF-8, US-ASCII and ISO-8859-1 are directly
+           |supported -- other encodings will transcoded to UTF-8 on the fly (and ingest may be slower).
+           |""".stripMargin)
+  encoding: String = "UTF-8"
+) extends IngestStreamConfiguration
+
 @title("Streamed Record Format")
 @docs("Format by which streamed records are decoded.")
 sealed abstract class StreamedRecordFormat

--- a/quine-endpoints/src/main/scala/com/thatdot/quine/routes/IngestRoutes.scala
+++ b/quine-endpoints/src/main/scala/com/thatdot/quine/routes/IngestRoutes.scala
@@ -303,15 +303,35 @@ final case class SQSIngest(
   @docs("maximum records to process per second") maximumPerSecond: Option[Int]
 ) extends IngestStreamConfiguration
 
+object WebsocketSimpleStartupIngest {
+  @unnamed
+  @title("Websockets Keepalive Protocol")
+  sealed abstract class KeepaliveProtocol
+  @unnamed
+  @title("Ping/Pong on interval")
+  @docs("Send empty websocket messages at the specified interval (in milliseconds)")
+  final case class PingPongInterval(intervalMillis: Int = 5000) extends KeepaliveProtocol
+  @unnamed
+  @title("Text Keepalive Message on Interval")
+  @docs("Send the same text-based Websocket message at the specified interval (in milliseconds)")
+  final case class SendMessageInterval(message: String, intervalMillis: Int = 5000) extends KeepaliveProtocol
+  @unnamed
+  @title("No Keepalive")
+  @docs("Only send data messages, no keepalives")
+  final case object NoKeepalive extends KeepaliveProtocol
+}
 @title("Websockets Ingest Stream (Simple Startup)")
 @unnamed
 @docs("A websocket stream started after a sequence of text messages")
-final case class WebsocketIngestSimpleStartup(
+final case class WebsocketSimpleStartupIngest(
+  @docs("format used to decode each incoming message")
   format: StreamedRecordFormat = IngestRoutes.defaultStreamedRecordFormat,
   @docs("websocket (ws: or wss:) url to connect to")
-  wsUrl: String,
+  url: String,
   @docs("initial messages to send to the server on connecting")
   initMessages: Seq[String] = Seq.empty,
+  @docs("what strategy to use for sending keepalive messages, if any")
+  keepAlive: WebsocketSimpleStartupIngest.KeepaliveProtocol = WebsocketSimpleStartupIngest.PingPongInterval(),
   @docs("maximum number of records to ingest simultaneously")
   parallelism: Int = IngestRoutes.defaultWriteParallelism,
   @docs(s"""text encoding used to read text messages in the stream. Only UTF-8, US-ASCII and ISO-8859-1 are directly
@@ -568,6 +588,8 @@ trait IngestSchemas extends endpoints4s.generic.JsonSchemas with AwsCredentialsS
     stringEnumeration(KafkaAutoOffsetReset.values)(_.name)
   implicit lazy val kafkaOffsetCommittingSchema: JsonSchema[KafkaOffsetCommitting] =
     genericJsonSchema[KafkaOffsetCommitting]
+  implicit lazy val wsKeepaliveSchema: JsonSchema[WebsocketSimpleStartupIngest.KeepaliveProtocol] =
+    genericJsonSchema[WebsocketSimpleStartupIngest.KeepaliveProtocol]
   implicit lazy val ingestStreamConfigurationSchema: JsonSchema[IngestStreamConfiguration] =
     genericJsonSchema[IngestStreamConfiguration].withExample(exampleIngestStreamInfo.settings)
   implicit lazy val ingestStreamStatsSchema: JsonSchema[IngestStreamStats] =

--- a/quine/recipes/certstream-firehose.yaml
+++ b/quine/recipes/certstream-firehose.yaml
@@ -7,8 +7,8 @@ description: |-
   connecting to the certstream firehose via SSL-encrypted websocket and printing to
   standard out each time a new certificate is detected
 ingestStreams:
-  - type: WebsocketIngestSimpleStartup
-    wsUrl: wss://certstream.calidog.io/
+  - type: WebsocketSimpleStartupIngest
+    url: wss://certstream.calidog.io/
     format:
       type: CypherJson
       query: |-

--- a/quine/recipes/certstream-firehose.yaml
+++ b/quine/recipes/certstream-firehose.yaml
@@ -1,0 +1,34 @@
+version: 1
+title: Certstream Firehose
+contributor: https://github.com/emanb29
+summary: Log new SSL certificate registrations
+description: |-
+  Reproduces the behavior of the certstream website (https://certstream.calidog.io/) by
+  connecting to the certstream firehose via SSL-encrypted websocket and printing to
+  standard out each time a new certificate is detected
+ingestStreams:
+  - type: WebsocketIngestSimpleStartup
+    wsUrl: wss://certstream.calidog.io/
+    format:
+      type: CypherJson
+      query: |-
+        CREATE ($that)
+standingQueries:
+  - pattern:
+      type: Cypher
+      query: MATCH (n) RETURN DISTINCT id(n) AS id
+    outputs:
+      log-new-nodes:
+        type: CypherQuery
+        query: |-
+          MATCH (n)
+          WHERE id(n) = $that.data.id
+          RETURN n
+        andThen:
+          type: PrintToStandardOut
+          logMode: FastSampling
+
+nodeAppearances: []
+quickQueries: []
+sampleQueries: []
+statusQuery: []

--- a/quine/recipes/certstream-firehose.yaml
+++ b/quine/recipes/certstream-firehose.yaml
@@ -18,17 +18,15 @@ standingQueries:
       type: Cypher
       query: MATCH (n) RETURN DISTINCT id(n) AS id
     outputs:
-      log-new-nodes:
+      log-new-certs:
         type: CypherQuery
         query: |-
           MATCH (n)
           WHERE id(n) = $that.data.id
-          RETURN n
+          RETURN n.data
         andThen:
           type: PrintToStandardOut
           logMode: FastSampling
-
 nodeAppearances: []
 quickQueries: []
 sampleQueries: []
-statusQuery: []

--- a/quine/src/main/scala/com/thatdot/quine/app/Recipe.scala
+++ b/quine/src/main/scala/com/thatdot/quine/app/Recipe.scala
@@ -186,6 +186,14 @@ object Recipe {
             deleteReadMessages,
             maximumPerSecond
           )
+        case WebsocketIngestSimpleStartup(format, wsUrl, initMessages, parallelism, encoding) =>
+          WebsocketIngestSimpleStartup(
+            format,
+            applySubstitution(wsUrl, values),
+            initMessages.map(_.subs),
+            parallelism,
+            encoding
+          )
         case FileIngest(
               format,
               path,

--- a/quine/src/main/scala/com/thatdot/quine/app/Recipe.scala
+++ b/quine/src/main/scala/com/thatdot/quine/app/Recipe.scala
@@ -186,11 +186,12 @@ object Recipe {
             deleteReadMessages,
             maximumPerSecond
           )
-        case WebsocketIngestSimpleStartup(format, wsUrl, initMessages, parallelism, encoding) =>
-          WebsocketIngestSimpleStartup(
+        case WebsocketSimpleStartupIngest(format, wsUrl, initMessages, keepAliveProtocol, parallelism, encoding) =>
+          WebsocketSimpleStartupIngest(
             format,
             applySubstitution(wsUrl, values),
             initMessages.map(_.subs),
+            keepAliveProtocol,
             parallelism,
             encoding
           )

--- a/quine/src/main/scala/com/thatdot/quine/app/importers/WebsocketSimpleStartup.scala
+++ b/quine/src/main/scala/com/thatdot/quine/app/importers/WebsocketSimpleStartup.scala
@@ -9,7 +9,6 @@ import scala.util.{Failure, Success}
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.IllegalUriException
 import akka.http.scaladsl.model.ws.{
   BinaryMessage,
   InvalidUpgradeResponse,
@@ -37,10 +36,11 @@ import com.thatdot.quine.routes.WebsocketSimpleStartupIngest.KeepaliveProtocol
 object WebsocketSimpleStartup {
   class UpgradeFailedException(cause: Throwable)
       extends RuntimeException("Unable to upgrade to websocket connection", cause) {
+
     def this(cause: String) = this(new Throwable(cause))
   }
 }
-case class WebsocketSimpleStartup(
+final case class WebsocketSimpleStartup(
   format: ImportFormat,
   wsUrl: String,
   initMessages: Seq[String],
@@ -51,7 +51,7 @@ case class WebsocketSimpleStartup(
   meter: IngestMeter,
   initialSwitchMode: SwitchMode
 ) extends LazyLogging {
-  @throws[IllegalUriException]("When the provided url is invalid")
+  @throws[IllegalArgumentException]("When the provided url is invalid")
   def stream(implicit graph: CypherOpsGraph): IngestSrcType[ControlSwitches] = {
     implicit val system: ActorSystem = graph.system
     val execToken = IngestSrcExecToken(s"WebSocket: $wsUrl")

--- a/quine/src/main/scala/com/thatdot/quine/app/importers/WebsocketSimpleStartup.scala
+++ b/quine/src/main/scala/com/thatdot/quine/app/importers/WebsocketSimpleStartup.scala
@@ -1,0 +1,105 @@
+package com.thatdot.quine.app.importers
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.IllegalUriException
+import akka.http.scaladsl.model.ws.{
+  BinaryMessage,
+  InvalidUpgradeResponse,
+  Message,
+  TextMessage,
+  ValidUpgrade,
+  WebSocketRequest
+}
+import akka.stream.KillSwitches
+import akka.stream.contrib.{SwitchMode, Valve}
+import akka.stream.scaladsl.{Flow, Keep, Source}
+import akka.util.ByteString
+import com.thatdot.quine.app.ControlSwitches
+import com.thatdot.quine.app.importers.WebsocketSimpleStartup.UpgradeFailedException
+import com.thatdot.quine.app.importers.serialization.ImportFormat
+import com.thatdot.quine.app.routes.IngestMeter
+import com.thatdot.quine.graph.CypherOpsGraph
+import com.thatdot.quine.graph.MasterStream.{IngestSrcExecToken, IngestSrcType}
+import com.typesafe.scalalogging.LazyLogging
+
+import java.nio.charset.Charset
+import scala.compat.ExecutionContexts
+import scala.util.{Failure, Success}
+object WebsocketSimpleStartup {
+  class UpgradeFailedException(cause: Throwable)
+      extends RuntimeException("Unable to upgrade to websocket connection", cause) {
+    def this(cause: String) = this(new Throwable(cause))
+  }
+}
+case class WebsocketSimpleStartup(
+  format: ImportFormat,
+  wsUrl: String,
+  initMessages: Seq[String],
+  parallelism: Int,
+  charset: Charset,
+  charsetTranscoder: Flow[ByteString, ByteString, NotUsed],
+  meter: IngestMeter,
+  initialSwitchMode: SwitchMode
+) extends LazyLogging {
+  @throws[IllegalUriException]("When the provided url is invalid")
+  def stream(implicit graph: CypherOpsGraph): IngestSrcType[ControlSwitches] = {
+    implicit val system: ActorSystem = graph.system
+    // NB Instead of killing this source with the downstream KillSwitch, we could switch this Source.never to a
+    // Source.maybe, completing it with None to kill the connection -- this is closer to the docs for
+    // webSocketClientFlow
+    val outboundMessages = Source.fromIterator(() => initMessages.iterator).map(TextMessage(_)).concat(Source.never)
+    val wsFlow = Http().webSocketClientFlow(WebSocketRequest(wsUrl))
+    val execToken = IngestSrcExecToken(s"WebSocket: $wsUrl")
+
+    val (websocketUpgraded, websocketSource) = outboundMessages
+      .viaMat(wsFlow)(Keep.right)
+      .preMaterialize()
+
+    Source
+      .futureSource(websocketUpgraded.transform {
+        // if the websocket upgrade fails, return an already-failed Source
+        case Success(InvalidUpgradeResponse(_, cause)) => Failure(new UpgradeFailedException(cause))
+        case Failure(ex) => Failure(new UpgradeFailedException(ex))
+        // the websocket upgrade succeeded: proceed with setting up the ingest stream source
+        case Success(ValidUpgrade(_, _)) =>
+          Success(
+            websocketSource
+              .viaMat(KillSwitches.single)(Keep.right)
+              .viaMat(Valve[Message](initialSwitchMode))(Keep.both)
+              .flatMapConcat { msg =>
+                val msgBytesSrc: Source[ByteString, _] =
+                  msg match {
+                    case textMessage: TextMessage =>
+                      textMessage.textStream
+                        .fold("")(_ + _)
+                        .map(ByteString.fromString(_, charset))
+                    case m: BinaryMessage =>
+                      m.dataStream.fold(ByteString.empty)(_ concat _)
+                  }
+                msgBytesSrc.mapConcat { bytes =>
+                  meter.mark(bytes.length)
+                  format
+                    .importMessageSafeBytes(bytes.toArray, graph.isSingleHost)
+                    .fold(
+                      { err =>
+                        logger.warn(s"Error decoding event data for event $msg", err)
+                        List.empty
+                      },
+                      List(_)
+                    )
+                }
+              }
+              .via(graph.ingestThrottleFlow)
+              .mapAsyncUnordered(parallelism)(format.writeToGraph(graph, _))
+              .map(_ => execToken)
+              .watchTermination() { case ((killSwitch, valveSwitch), doneFut) =>
+                valveSwitch.map(v => ControlSwitches(killSwitch, v, doneFut))(ExecutionContexts.parasitic)
+              }
+          )
+      }(ExecutionContexts.parasitic))
+      .mapMaterializedValue(_.flatten)
+
+  }
+}

--- a/quine/src/main/scala/com/thatdot/quine/app/importers/WebsocketSimpleStartup.scala
+++ b/quine/src/main/scala/com/thatdot/quine/app/importers/WebsocketSimpleStartup.scala
@@ -1,5 +1,10 @@
 package com.thatdot.quine.app.importers
 
+import java.nio.charset.Charset
+
+import scala.compat.ExecutionContexts
+import scala.util.{Failure, Success}
+
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
@@ -16,17 +21,15 @@ import akka.stream.KillSwitches
 import akka.stream.contrib.{SwitchMode, Valve}
 import akka.stream.scaladsl.{Flow, Keep, Source}
 import akka.util.ByteString
+
+import com.typesafe.scalalogging.LazyLogging
+
 import com.thatdot.quine.app.ControlSwitches
 import com.thatdot.quine.app.importers.WebsocketSimpleStartup.UpgradeFailedException
 import com.thatdot.quine.app.importers.serialization.ImportFormat
 import com.thatdot.quine.app.routes.IngestMeter
 import com.thatdot.quine.graph.CypherOpsGraph
 import com.thatdot.quine.graph.MasterStream.{IngestSrcExecToken, IngestSrcType}
-import com.typesafe.scalalogging.LazyLogging
-
-import java.nio.charset.Charset
-import scala.compat.ExecutionContexts
-import scala.util.{Failure, Success}
 object WebsocketSimpleStartup {
   class UpgradeFailedException(cause: Throwable)
       extends RuntimeException("Unable to upgrade to websocket connection", cause) {

--- a/quine/src/main/scala/com/thatdot/quine/app/importers/WebsocketSimpleStartup.scala
+++ b/quine/src/main/scala/com/thatdot/quine/app/importers/WebsocketSimpleStartup.scala
@@ -3,6 +3,7 @@ package com.thatdot.quine.app.importers
 import java.nio.charset.Charset
 
 import scala.compat.ExecutionContexts
+import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Success}
 
 import akka.NotUsed
@@ -17,6 +18,7 @@ import akka.http.scaladsl.model.ws.{
   ValidUpgrade,
   WebSocketRequest
 }
+import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.stream.KillSwitches
 import akka.stream.contrib.{SwitchMode, Valve}
 import akka.stream.scaladsl.{Flow, Keep, Source}
@@ -30,6 +32,8 @@ import com.thatdot.quine.app.importers.serialization.ImportFormat
 import com.thatdot.quine.app.routes.IngestMeter
 import com.thatdot.quine.graph.CypherOpsGraph
 import com.thatdot.quine.graph.MasterStream.{IngestSrcExecToken, IngestSrcType}
+import com.thatdot.quine.routes.WebsocketSimpleStartupIngest
+import com.thatdot.quine.routes.WebsocketSimpleStartupIngest.KeepaliveProtocol
 object WebsocketSimpleStartup {
   class UpgradeFailedException(cause: Throwable)
       extends RuntimeException("Unable to upgrade to websocket connection", cause) {
@@ -40,6 +44,7 @@ case class WebsocketSimpleStartup(
   format: ImportFormat,
   wsUrl: String,
   initMessages: Seq[String],
+  keepaliveProtocol: KeepaliveProtocol,
   parallelism: Int,
   charset: Charset,
   charsetTranscoder: Flow[ByteString, ByteString, NotUsed],
@@ -49,12 +54,30 @@ case class WebsocketSimpleStartup(
   @throws[IllegalUriException]("When the provided url is invalid")
   def stream(implicit graph: CypherOpsGraph): IngestSrcType[ControlSwitches] = {
     implicit val system: ActorSystem = graph.system
+    val execToken = IngestSrcExecToken(s"WebSocket: $wsUrl")
     // NB Instead of killing this source with the downstream KillSwitch, we could switch this Source.never to a
     // Source.maybe, completing it with None to kill the connection -- this is closer to the docs for
     // webSocketClientFlow
     val outboundMessages = Source.fromIterator(() => initMessages.iterator).map(TextMessage(_)).concat(Source.never)
-    val wsFlow = Http().webSocketClientFlow(WebSocketRequest(wsUrl))
-    val execToken = IngestSrcExecToken(s"WebSocket: $wsUrl")
+    val baseHttpClientSettings = ClientConnectionSettings(system)
+    // Copy (and potentially tweak) baseHttpClientSettings for websockets usage
+    val httpClientSettings = keepaliveProtocol match {
+      case WebsocketSimpleStartupIngest.PingPongInterval(intervalMillis) =>
+        baseHttpClientSettings.withWebsocketSettings(
+          baseHttpClientSettings.websocketSettings.withPeriodicKeepAliveMaxIdle(intervalMillis.millis)
+        )
+      case WebsocketSimpleStartupIngest.SendMessageInterval(message, intervalMillis) =>
+        baseHttpClientSettings.withWebsocketSettings(
+          baseHttpClientSettings.websocketSettings
+            .withPeriodicKeepAliveMaxIdle(intervalMillis.millis)
+            .withPeriodicKeepAliveData(() => ByteString(message, charset))
+        )
+      case WebsocketSimpleStartupIngest.NoKeepalive => baseHttpClientSettings
+    }
+    val wsFlow = Http().webSocketClientFlow(
+      WebSocketRequest(wsUrl),
+      settings = httpClientSettings
+    )
 
     val (websocketUpgraded, websocketSource) = outboundMessages
       .viaMat(wsFlow)(Keep.right)

--- a/quine/src/main/scala/com/thatdot/quine/app/importers/package.scala
+++ b/quine/src/main/scala/com/thatdot/quine/app/importers/package.scala
@@ -166,12 +166,13 @@ package object importers extends StrictLogging {
         )
         sqsStream.stream
 
-      case WebsocketIngestSimpleStartup(format, wsUrl, initMessages, parallelism, encoding) =>
+      case WebsocketSimpleStartupIngest(format, wsUrl, initMessages, keepAliveProtocol, parallelism, encoding) =>
         val (charset, transcoder) = getTranscoder(encoding)
         WebsocketSimpleStartup(
           importFormatFor(format),
           wsUrl,
           initMessages,
+          keepAliveProtocol,
           parallelism,
           charset,
           transcoder,

--- a/quine/src/main/scala/com/thatdot/quine/app/importers/package.scala
+++ b/quine/src/main/scala/com/thatdot/quine/app/importers/package.scala
@@ -231,7 +231,9 @@ package object importers extends StrictLogging {
       case userCharset @ (StandardCharsets.UTF_8 | StandardCharsets.ISO_8859_1 | StandardCharsets.US_ASCII) =>
         userCharset -> Flow[ByteString]
       case otherCharset =>
-        logger.warn(s"File ingest does not directly support $otherCharset - transcoding through UTF-8 first")
+        logger.warn(
+          s"Charset-sensitive ingest does not directly support $otherCharset - transcoding through UTF-8 first"
+        )
         StandardCharsets.UTF_8 -> TextFlow.transcoding(otherCharset, StandardCharsets.UTF_8)
     }
 

--- a/quine/src/main/scala/com/thatdot/quine/app/routes/WebSocketQueryProtocolServer.scala
+++ b/quine/src/main/scala/com/thatdot/quine/app/routes/WebSocketQueryProtocolServer.scala
@@ -94,7 +94,7 @@ trait WebSocketQueryProtocolServer
           clientMessages.out
             .flatMapConcat {
               case textMessage: ws.TextMessage =>
-                textMessage.getStreamedText
+                textMessage.textStream
                   .fold("")(_ + _)
                   .map(deserializeClientTextMessage)
               case _: ws.BinaryMessage =>


### PR DESCRIPTION
- Adds a simplified ingest source for websockets
- Adds a recipe demonstrating websocket usage.
- Also avoids a usage of the akka java DSL (scala DSL was almost certainly intended)

Constraints of the ingest source:
- This source will send a series of text messages on first connecting to the websockets server. These messages are sent as fast as possible, and must be text-kinded (ie, not binary messages)
- The source cannot nontrivial keepalive protocols
- The source is implemented via akka streams' HTTP client and inherits the limitations thereof. Most notably, half-closed sessions are not supported.