### PR TITLE
Don't include labels twice in literal operation

### DIFF
--- a/quine-core/src/main/scala/com/thatdot/quine/graph/behavior/LiteralCommandBehavior.scala
+++ b/quine-core/src/main/scala/com/thatdot/quine/graph/behavior/LiteralCommandBehavior.scala
@@ -37,7 +37,7 @@ trait LiteralCommandBehavior extends Actor with BaseNodeActor with QuineIdOps wi
 
     case r @ RemoveHalfEdgeCommand(he, _) => r ?! processEvent(EdgeRemoved(he))
 
-    case g @ GetRawPropertiesCommand(_) => g ?! RawPropertiesMap(getLabels(), properties)
+    case g @ GetRawPropertiesCommand(_) => g ?! RawPropertiesMap(getLabels(), properties - graph.labelsProperty)
 
     case r @ GetPropertiesAndEdges(_) =>
       r ?! PropertiesAndEdges(qid, properties, edges.toSet)


### PR DESCRIPTION
The `LiteralMessage.GetRawPropertiesCommand` includes labels twice: once
in the labels field and a second time as an entry in the properties map.
This changes that behaviour to omit the label from the properties.

This fixes #4 since `UserDefinedProcedure.getAsCypherNode` (which is
used by `recentNodes` and other procedures) now doesn't include the
label as a property.