### PR TITLE
Pull deduplicateEvents out of NodeActor.processEvents.

### DIFF
--- a/quine-core/src/main/scala/com/thatdot/quine/graph/NodeActor.scala
+++ b/quine-core/src/main/scala/com/thatdot/quine/graph/NodeActor.scala
@@ -120,7 +120,7 @@ private[graph] class NodeActor(
     */
   protected def syncStandingQueries(): Unit =
     if (atTime.isEmpty) {
-      `updateUniversalQueriesOnWake`()
+      updateUniversalQueriesOnWake()
       updateUniversalCypherQueriesOnWake()
     }
 


### PR DESCRIPTION
This change extracts a function for deduplicating events out of NodeActor.processEvents.

Since this code is likely to be called frequently, minimizing heap allocations could have performance benefits. This implementation attempts to minimize allocations by:

- Eliminating the pair of reverse operations completely (as noted in a TODO in the original),
- Don't build the Sets that track whether events have been seen before, and
- Don't copy the mutable ArrayBuffer before returning it.

Since the Sets that track state are not built, deduplication needs to linear search the later events. This could be problematic for very large sequences of event. That would have to be a very large sequence of events to be significant.

It returns a `mutable.ArrayBuffer` as a `Seq` without coping. Since this is only used internally to NodeActor, there is no possibility for this mutable state to escape, so there is no need to do the defensive copy.