### PR TITLE
Cypher: fix variables in scoped expressions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -118,6 +118,7 @@ lazy val `quine-cypher`: Project = project
   .settings(`scala 2.12`)
   .dependsOn(`quine-core` % "compile->compile;test->test")
   .settings(
+    scalacOptions += "-language:reflectiveCalls",
     libraryDependencies ++= Seq(
       "org.opencypher" % "expressions-9.0" % openCypherV,
       "org.opencypher" % "front-end-9.0" % openCypherV,

--- a/quine-cypher/src/main/scala/com/thatdot/quine/compiler/cypher/Expression.scala
+++ b/quine-cypher/src/main/scala/com/thatdot/quine/compiler/cypher/Expression.scala
@@ -148,7 +148,7 @@ object Expression {
 
     case expressions.ReduceExpression(expressions.ReduceScope(acc, variable, expr), init, list) =>
       val freshVar = variable.renameId(UnNamedNameGenerator.name(variable.position.newUniquePos()))
-      val freshAcc = variable.renameId(UnNamedNameGenerator.name(acc.position.newUniquePos()))
+      val freshAcc = acc.renameId(UnNamedNameGenerator.name(acc.position.newUniquePos()))
       val freshExpr = expr
         .copyAndReplace(variable)
         .by(freshVar)

--- a/quine-cypher/src/main/scala/com/thatdot/quine/compiler/cypher/Expression.scala
+++ b/quine-cypher/src/main/scala/com/thatdot/quine/compiler/cypher/Expression.scala
@@ -18,7 +18,7 @@ object Expression {
 
   /** Run an action in a new scope.
     *
-    * This means that columns/variables defined in the argument are visibly for
+    * This means that columns/variables defined in the argument are visible for
     * the rest of its execution, but not once `scoped` has finished running.
     *
     * @param wq action to run in a new scope
@@ -92,39 +92,54 @@ object Expression {
         end1 <- end.traverse[WithQueryT[CompM, *], cypher.Expr](compile)
       } yield cypher.Expr.ListSlice(expr1, start1, end1)
 
-    // All of these turn into list comprehensions
+    /* All of these turn into list comprehensions
+     *
+     * Also, for reasons that aren't clear to me, this is one place in openCyphe
+     * where the `variable` being bound may not have been freshened (it may shadow
+     * another variable of the same name). Since the rest of our compilation
+     * scoping assumes fresh names, we defensively manually replace the bound
+     * variable with a fresh one.
+     */
     case expressions.FilterExpression(expressions.FilterScope(variable, predOpt), list) =>
+      val freshVar = variable.renameId(UnNamedNameGenerator.name(variable.position.newUniquePos()))
+      val freshPredOpt = predOpt.map(_.copyAndReplace(variable).by(freshVar))
       for {
         (varExpr, predicate) <- scoped {
           for {
-            varExpr <- WithQueryT.lift(CompM.addColumn(variable))
-            predicateOpt <- predOpt.traverse[WithQueryT[CompM, *], cypher.Expr](compile)
+            varExpr <- WithQueryT.lift(CompM.addColumn(freshVar))
+            predicateOpt <- freshPredOpt.traverse[WithQueryT[CompM, *], cypher.Expr](compile)
             predicate = predicateOpt.getOrElse(cypher.Expr.True)
           } yield (varExpr, predicate)
         }
         list1 <- compile(list)
       } yield cypher.Expr.ListComprehension(varExpr.id, list1, predicate, varExpr)
     case expressions.ExtractExpression(expressions.ExtractScope(variable, predOpt, extOpt), list) =>
+      val freshVar = variable.renameId(UnNamedNameGenerator.name(variable.position.newUniquePos()))
+      val freshPredOpt = predOpt.map(_.copyAndReplace(variable).by(freshVar))
+      val freshExtOpt = extOpt.map(_.copyAndReplace(variable).by(freshVar))
       for {
         (varExpr, predicate, extract) <- scoped {
           for {
-            varExpr <- WithQueryT.lift(CompM.addColumn(variable))
-            predicateOpt <- predOpt.traverse[WithQueryT[CompM, *], cypher.Expr](compile)
+            varExpr <- WithQueryT.lift(CompM.addColumn(freshVar))
+            predicateOpt <- freshPredOpt.traverse[WithQueryT[CompM, *], cypher.Expr](compile)
             predicate = predicateOpt.getOrElse(cypher.Expr.True)
-            extractOpt <- extOpt.traverse[WithQueryT[CompM, *], cypher.Expr](compile)
+            extractOpt <- freshExtOpt.traverse[WithQueryT[CompM, *], cypher.Expr](compile)
             extract = extractOpt.getOrElse(varExpr)
           } yield (varExpr, predicate, extract)
         }
         list1 <- compile(list)
       } yield cypher.Expr.ListComprehension(varExpr.id, list1, predicate, extract)
     case expressions.ListComprehension(expressions.ExtractScope(variable, predOpt, extOpt), list) =>
+      val freshVar = variable.renameId(UnNamedNameGenerator.name(variable.position.newUniquePos()))
+      val freshPredOpt = predOpt.map(_.copyAndReplace(variable).by(freshVar))
+      val freshExtOpt = extOpt.map(_.copyAndReplace(variable).by(freshVar))
       for {
         (varExpr, predicate, extract) <- scoped {
           for {
-            varExpr <- WithQueryT.lift(CompM.addColumn(variable))
-            predicateOpt <- predOpt.traverse[WithQueryT[CompM, *], cypher.Expr](compile)
+            varExpr <- WithQueryT.lift(CompM.addColumn(freshVar))
+            predicateOpt <- freshPredOpt.traverse[WithQueryT[CompM, *], cypher.Expr](compile)
             predicate = predicateOpt.getOrElse(cypher.Expr.True)
-            extractOpt <- extOpt.traverse[WithQueryT[CompM, *], cypher.Expr](compile)
+            extractOpt <- freshExtOpt.traverse[WithQueryT[CompM, *], cypher.Expr](compile)
             extract = extractOpt.getOrElse(varExpr)
           } yield (varExpr, predicate, extract)
         }
@@ -132,59 +147,74 @@ object Expression {
       } yield cypher.Expr.ListComprehension(varExpr.id, list1, predicate, extract)
 
     case expressions.ReduceExpression(expressions.ReduceScope(acc, variable, expr), init, list) =>
+      val freshVar = variable.renameId(UnNamedNameGenerator.name(variable.position.newUniquePos()))
+      val freshAcc = variable.renameId(UnNamedNameGenerator.name(acc.position.newUniquePos()))
+      val freshExpr = expr
+        .copyAndReplace(variable)
+        .by(freshVar)
+        .copyAndReplace(acc)
+        .by(freshAcc)
       for {
         init1 <- compile(init)
         list1 <- compile(list)
         (varExpr, accExpr, expr1) <- scoped {
           for {
-            varExpr <- WithQueryT.lift(CompM.addColumn(variable))
-            accExpr <- WithQueryT.lift(CompM.addColumn(acc))
-            expr1 <- compile(expr)
+            varExpr <- WithQueryT.lift(CompM.addColumn(freshVar))
+            accExpr <- WithQueryT.lift(CompM.addColumn(freshAcc))
+            expr1 <- compile(freshExpr)
           } yield (varExpr, accExpr, expr1)
         }
       } yield cypher.Expr.ReduceList(accExpr.id, init1, varExpr.id, list1, expr1)
 
     case expressions.AllIterablePredicate(expressions.FilterScope(variable, predOpt), list) =>
       require(predOpt.nonEmpty)
+      val freshVar = variable.renameId(UnNamedNameGenerator.name(variable.position.newUniquePos()))
+      val freshPredOpt = predOpt.map(_.copyAndReplace(variable).by(freshVar))
       for {
         list1 <- compile(list)
         (varExpr, pred1) <- scoped {
           for {
-            varExpr <- WithQueryT.lift(CompM.addColumn(variable))
-            pred1 <- compile(predOpt.get)
+            varExpr <- WithQueryT.lift(CompM.addColumn(freshVar))
+            pred1 <- compile(freshPredOpt.get)
           } yield (varExpr, pred1)
         }
       } yield cypher.Expr.AllInList(varExpr.id, list1, pred1)
     case expressions.AnyIterablePredicate(expressions.FilterScope(variable, predOpt), list) =>
       require(predOpt.nonEmpty)
+      val freshVar = variable.renameId(UnNamedNameGenerator.name(variable.position.newUniquePos()))
+      val freshPredOpt = predOpt.map(_.copyAndReplace(variable).by(freshVar))
       for {
         list1 <- compile(list)
         (varExpr, pred1) <- scoped {
           for {
-            varExpr <- WithQueryT.lift(CompM.addColumn(variable))
-            pred1 <- compile(predOpt.get)
+            varExpr <- WithQueryT.lift(CompM.addColumn(freshVar))
+            pred1 <- compile(freshPredOpt.get)
           } yield (varExpr, pred1)
         }
       } yield cypher.Expr.AnyInList(varExpr.id, list1, pred1)
     case expressions.NoneIterablePredicate(expressions.FilterScope(variable, predOpt), list) =>
       require(predOpt.nonEmpty)
+      val freshVar = variable.renameId(UnNamedNameGenerator.name(variable.position.newUniquePos()))
+      val freshPredOpt = predOpt.map(_.copyAndReplace(variable).by(freshVar))
       for {
         list1 <- compile(list)
         (varExpr, pred1) <- scoped {
           for {
-            varExpr <- WithQueryT.lift(CompM.addColumn(variable))
-            pred1 <- compile(predOpt.get)
+            varExpr <- WithQueryT.lift(CompM.addColumn(freshVar))
+            pred1 <- compile(freshPredOpt.get)
           } yield (varExpr, pred1)
         }
       } yield cypher.Expr.Not(cypher.Expr.AnyInList(varExpr.id, list1, pred1))
     case expressions.SingleIterablePredicate(expressions.FilterScope(variable, predOpt), list) =>
       require(predOpt.nonEmpty)
+      val freshVar = variable.renameId(UnNamedNameGenerator.name(variable.position.newUniquePos()))
+      val freshPredOpt = predOpt.map(_.copyAndReplace(variable).by(freshVar))
       for {
         list1 <- compile(list)
         (varExpr, pred1) <- scoped {
           for {
-            varExpr <- WithQueryT.lift(CompM.addColumn(variable))
-            pred1 <- compile(predOpt.get)
+            varExpr <- WithQueryT.lift(CompM.addColumn(freshVar))
+            pred1 <- compile(freshPredOpt.get)
           } yield (varExpr, pred1)
         }
       } yield cypher.Expr.SingleInList(varExpr.id, list1, pred1)

--- a/quine-cypher/src/test/scala/com/thatdot/quine/VariableLengthRelationshipPattern.scala
+++ b/quine-cypher/src/test/scala/com/thatdot/quine/VariableLengthRelationshipPattern.scala
@@ -438,4 +438,25 @@ class VariableLengthRelationshipPatternMatrix extends CypherHarness("variable-le
       expectedCanContainAllNodeScan = true
     )
   }
+
+  describe("variable length relationships with constraints") {
+    testQuery(
+      "MATCH (a)-[*1]->(b)-->(c) RETURN a.name, c.name",
+      expectedColumns = Vector("a.name", "c.name"),
+      expectedRows = Seq(
+        Vector(Expr.Str("Morpheus"), Expr.Str("Agent Smith")),
+        Vector(Expr.Str("Neo"), Expr.Str("Cypher")),
+        Vector(Expr.Str("Neo"), Expr.Str("Trinity")),
+        Vector(Expr.Str("Cypher"), Expr.Str("The Architect"))
+      ),
+      expectedCanContainAllNodeScan = true
+    )
+
+    testQuery(
+      "MATCH (a)-[:foo|:bar]->(b)-[:bar*]->(c) RETURN null",
+      expectedColumns = Vector("null"),
+      expectedRows = Seq.empty,
+      expectedCanContainAllNodeScan = true
+    )
+  }
 }


### PR DESCRIPTION
Apparently, openCypher's freshening of variables does _not_ extend to
scoped expressions. We can fix this by manually "freshening" the
variables in the expression subscopes.

The better solution would be to extend the scoping information
maintained by the compiler to include a stack of scopes (when you enter
a new scope you push and when you exit you pop). Unfortunately, that's
not too helpful in Quine's case since the runtime still needs distinct
column names (since it uses `QueryContext ~ Map[Symbol, Value]` instead
of `QueryContext ~ Vector[Value]`). If the runtime representation of
query contexts changed, the fix to this problem would be more in line
with the usual compiler approach to scoping.