### PR TITLE
Cypher: fix scoping around subqueries

### DIFF
--- a/quine-core/src/main/scala/com/thatdot/quine/graph/cypher/Interpreter.scala
+++ b/quine-core/src/main/scala/com/thatdot/quine/graph/cypher/Interpreter.scala
@@ -1105,5 +1105,12 @@ trait CypherInterpreter[Start <: Location] extends ProcedureExecutionLocation {
   )(implicit
     parameters: Parameters
   ): Source[QueryContext, _] =
-    interpret(query.subQuery, context).map(context ++ _)
+    /* Variable scoping here is tricky:
+     *
+     *   - subquery runs against only the imported subcontext
+     *   - subquery output columns get _prepended_ to existing columns (unlike `with` or `unwind`)
+     *
+     * Collisions between subquery column outputs and existing columns are ruled out statically.
+     */
+    interpret(query.subQuery, context.subcontext(query.importedVariables)).map(_ ++ context)
 }

--- a/quine-core/src/main/scala/com/thatdot/quine/graph/cypher/Query.scala
+++ b/quine-core/src/main/scala/com/thatdot/quine/graph/cypher/Query.scala
@@ -746,9 +746,11 @@ object Query {
     * the initial input columns back to the subquery outputs.
     *
     * @param subQuery inner query
+    * @param importvariables which variables to import into the subquery
     */
   final case class SubQuery[+Start <: Location](
     subQuery: Query[Start],
+    importedVariables: Vector[Symbol],
     columns: Columns = Columns.Omitted
   ) extends Query[Start] {
     def isReadOnly: Boolean = subQuery.isReadOnly

--- a/quine-core/src/main/scala/com/thatdot/quine/graph/cypher/QueryContext.scala
+++ b/quine-core/src/main/scala/com/thatdot/quine/graph/cypher/QueryContext.scala
@@ -1,5 +1,7 @@
 package com.thatdot.quine.graph.cypher
 
+import scala.collection.compat._
+
 import com.thatdot.quine.model.QuineIdProvider
 
 /** Container for query results
@@ -29,6 +31,19 @@ final case class QueryContext(
   def apply(k: Symbol): Value = environment(k)
   def get(k: Symbol): Option[Value] = environment.get(k)
   def getOrElse(k: Symbol, v: => Value): Value = environment.getOrElse(k, v)
+
+  /** Extract and re-order a subset of the context (eg. when importing into a subquery
+    *
+    * @param importedColumns columns to extract
+    * @return subcontext containing only the specified imported columns
+    */
+  def subcontext(importedColumns: Seq[Symbol]): QueryContext =
+    // TODO: if `QueryContext` was ordered, re-order it according to `importedColumns`
+    QueryContext(
+      environment.view
+        .filterKeys(importedColumns.contains)
+        .toMap
+    )
 
   def pretty: String = environment
     .map { case (k, v) => s"${k.name}: ${v.pretty}" }

--- a/quine-cypher/src/main/scala/com/thatdot/quine/compiler/cypher/QueryScopeInfo.scala
+++ b/quine-cypher/src/main/scala/com/thatdot/quine/compiler/cypher/QueryScopeInfo.scala
@@ -66,7 +66,7 @@ final case class QueryScopeInfo(
     * @return context with the variable and expression for reading the variable
     */
   def addColumn(variable: Symbol): (QueryScopeInfo, Expr.Variable) = {
-    require(!columnIdx.contains(variable), "variable is already in context")
+    require(!columnIdx.contains(variable), s"variable $variable is already in context")
     val scope = QueryScopeInfo(
       anchoredNodes = anchoredNodes - variable,
       columnIdx = columnIdx + (variable -> columnIdx.size),

--- a/quine-cypher/src/main/scala/com/thatdot/quine/compiler/cypher/Variables.scala
+++ b/quine-cypher/src/main/scala/com/thatdot/quine/compiler/cypher/Variables.scala
@@ -431,10 +431,10 @@ trait VariableRewriter[Start <: Location] {
     query: SubQuery[Start],
     columnsIn: Columns
   ): SubQuery[Start] = {
-    val subQuery = convertQuery(query.subQuery, columnsIn)
+    val subQuery = convertQuery(query.subQuery, Columns.Specified(query.importedVariables))
     query.copy(
       subQuery = subQuery,
-      columns = columnsIn ++ subQuery.columns
+      columns = subQuery.columns ++ columnsIn
     )
   }
 }


### PR DESCRIPTION
Previously, subqueries would just extend the existing scope. That's not
the expected Cypher behaviour though - the expectation is that only
imported columns (the `WITH` inside the `CALL`) get pulled in. In
addition, the subquery in the `CALL { .. }` can be the union of queries
that import different subsets of variables from the outer scope!

All this requires a change to the internal `Query.SubQuery` IR and its
semantics as well as tracking scope much more carefully in the presence
of subqueries (eg. to _remove_ variables from scope).