### PR TITLE
Cypher: better detection of query anchors

### DIFF
--- a/quine-cypher/src/test/scala/com/thatdot/quine/QueryStaticTest.scala
+++ b/quine-cypher/src/test/scala/com/thatdot/quine/QueryStaticTest.scala
@@ -142,5 +142,13 @@ class QueryStaticTest extends CypherHarness("query-static-tests") {
       expectedIsIdempotent = true,
       expectedCanContainAllNodeScan = false
     )
+    testQueryStaticAnalysis(
+      queryText =
+        "UNWIND [{}, {}] AS s MATCH (a), (b) WHERE strId(a) = s.foo AND strId(b) = s.bar CREATE (a)-[:baz]->(b)",
+      expectedIsReadOnly = false,
+      expectedCannotFail = false,
+      expectedIsIdempotent = true,
+      expectedCanContainAllNodeScan = false
+    )
   }
 }


### PR DESCRIPTION
Some queries that should have been fully anchored weren't. The test that
is added is an example: prior to this commit, that test fails since there
is an all-node-scan

The issue boils down to not openCypher rewriting equality `x = y` into
`x IN [y]` or `y IN [x]` and `quine-cypher` not recognizing all of those
in the same way.
