### PR TITLE
Cypher: fix asymmetric `Or` branches from `Merge`

### DIFF
--- a/quine-cypher/src/test/scala/com/thatdot/quine/QueryStaticTest.scala
+++ b/quine-cypher/src/test/scala/com/thatdot/quine/QueryStaticTest.scala
@@ -87,6 +87,13 @@ class QueryStaticTest extends CypherHarness("query-static-tests") {
       expectedCanContainAllNodeScan = false
     )
     testQueryStaticAnalysis(
+      queryText = "MATCH (a), (b), (p), (e), (c) MERGE (a)-[:A]->(b)-[:B]->(p)-[:C]->(c)-[:D]->(e)",
+      expectedIsReadOnly = false,
+      expectedCannotFail = false,
+      expectedIsIdempotent = true,
+      expectedCanContainAllNodeScan = true
+    )
+    testQueryStaticAnalysis(
       queryText = "return duration({ days: 24 })",
       expectedIsReadOnly = true,
       expectedCannotFail = false,


### PR DESCRIPTION
One of the invariants of `Query.Or(lhs, rhs)` is that the columns in
`lhs` should match the columns in `rhs` (really they should be in the
same order, but the runtime's columns are unordered, so that point is a
little tenuous).

This invariant was violated in queries like the one added in tests. The
crux is that the implied `MATCH` in the `MERGE` may bind additional
variables that aren't needed or bound for the implied `CREATE`. This
means that sometimes you end up with an `Or(matchQuery, createQuery)`
where the `matchQuery` has extra columns not in the `createQuery`.

The fix is straightforward: since the variables bound in the `CREATE`
are always a subset of those bound in the `MATCH`, we can adjust the
`MATCH` side of the query to keep only the same variables coming out of
the `CREATE` side.
