### PR TITLE
Fix Cypher miscompilation in `WITH DISTINCT`

### DIFF
--- a/quine-cypher/src/main/scala/com/thatdot/quine/compiler/cypher/QueryPart.scala
+++ b/quine-cypher/src/main/scala/com/thatdot/quine/compiler/cypher/QueryPart.scala
@@ -1000,7 +1000,7 @@ object QueryPart {
           deduped <- isDistinct match {
             case false => CompM.pure[cypher.Query[cypher.Location.Anywhere]](grouped)
             case true =>
-              clause.returnColumns
+              items.aliases.toList
                 .traverse(CompM.getVariable(_, clause))
                 .map(distinctBy => cypher.Query.Distinct(distinctBy, grouped))
           }

--- a/quine-cypher/src/test/scala/com/thatdot/quine/compiler/cypher/CypherComplete.scala
+++ b/quine-cypher/src/test/scala/com/thatdot/quine/compiler/cypher/CypherComplete.scala
@@ -795,6 +795,21 @@ class CypherComplete extends CypherHarness("cypher-complete-tests") {
       )
     }
   }
+
+  describe("DISTINCT in a WITH clause") {
+    testQuery(
+      "UNWIND [1,2,1] AS x WITH DISTINCT(x) AS y UNWIND [3,4] AS z RETURN y, z",
+      expectedColumns = Vector("y", "z"),
+      expectedRows = Seq(
+        Vector(Expr.Integer(1L), Expr.Integer(3L)),
+        Vector(Expr.Integer(1L), Expr.Integer(4L)),
+        Vector(Expr.Integer(2L), Expr.Integer(3L)),
+        Vector(Expr.Integer(2L), Expr.Integer(4L))
+      ),
+      expectedIsReadOnly = true,
+      expectedCannotFail = true
+    )
+  }
 }
 
 // For testing only...


### PR DESCRIPTION
Compilation was expecting the `returnItems` to be the distinct criteria, but apparently that is only set for actual `RETURN` clauses - other projection clauses such as `WITH` only set `items: ReturnItems` from which you can extract the bound variables.

The old buggy behaviour would have been

  1. `WITH DISTINCT` builds up the disinct criteria from `.returnItems`...

  2. Since that's empty you get a distinct criteria that is an empty list...

  3. Since there's exactly one "empty list" value, the interpreter would always let through exactly one value (the `seen` set would start empty then repeatedly try to add `Seq[Value]()`)