### PR TITLE
change the typing of ssl.password to String instead of Array[char]

### DIFF
--- a/quine/src/main/scala/com/thatdot/quine/app/config/WebServerConfig.scala
+++ b/quine/src/main/scala/com/thatdot/quine/app/config/WebServerConfig.scala
@@ -7,7 +7,7 @@ import org.apache.pekko.http.scaladsl.model.Uri
 
 import com.thatdot.quine.util.{Host, Port}
 
-final case class SslConfig(path: File, password: Array[Char])
+final case class SslConfig(path: File, password: String)
 
 trait WebServerConfig {
   def address: Host
@@ -20,7 +20,7 @@ final case class WebServerBindConfig(
   enabled: Boolean = true,
   ssl: Option[SslConfig] = (sys.env.get("SSL_KEYSTORE_PATH"), sys.env.get("SSL_KEYSTORE_PASSWORD")) match {
     case (None, None) => None
-    case (Some(path), Some(password)) => Some(SslConfig(new File(path), password.toCharArray))
+    case (Some(path), Some(password)) => Some(SslConfig(new File(path), password))
     case (Some(_), None) => sys.error("'SSL_KEYSTORE_PATH' was specified but 'SSL_KEYSTORE_PASSWORD' was not")
     case (None, Some(_)) => sys.error("'SSL_KEYSTORE_PASSWORD' was specified but 'SSL_KEYSTORE_PATH'  was not")
   },

--- a/quine/src/main/scala/com/thatdot/quine/app/routes/BaseAppRoutes.scala
+++ b/quine/src/main/scala/com/thatdot/quine/app/routes/BaseAppRoutes.scala
@@ -91,7 +91,7 @@ trait BaseAppRoutes extends LazySafeLogging with endpoints4s.pekkohttp.server.En
     ssl
       .fold(serverBuilder) { ssl =>
         serverBuilder.enableHttps(
-          ConnectionContext.httpsServer(SslHelper.sslContextFromKeystore(ssl.path, ssl.password)),
+          ConnectionContext.httpsServer(SslHelper.sslContextFromKeystore(ssl.path, ssl.password.toCharArray())),
         )
       }
       .bind(


### PR DESCRIPTION
# Description

This fixes the issue with setting the password in SSL config

Fixes # (issue)

https://github.com/thatdot/quine/issues/40

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Use this example config
https://quine.io/reference/config/quine-webserver-advertise/#adding-tls-security

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ x] Manually run java -Dconfig.file=./acme.conf -jar ./quine.jar 

**Test Configuration**:
* SDK: openjdk-21

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
