### PR TITLE
Remove use of `SELECT COUNT(*)` from Cassandra persistor

### DIFF
--- a/quine-cassandra-persistor/src/main/scala/com/thatdot/quine/persistor/cassandra/CassandraPersistor.scala
+++ b/quine-cassandra-persistor/src/main/scala/com/thatdot/quine/persistor/cassandra/CassandraPersistor.scala
@@ -230,7 +230,8 @@ abstract class CassandraPersistor(
   override def deleteMultipleValuesStandingQueryStates(id: QuineId): Future[Unit] =
     standingQueryStates.deleteStandingQueryStates(id)
 
-  def containsMultipleValuesStates(): Future[Boolean] = standingQueryStates.containsMultipleValuesStates()
+  def containsMultipleValuesStates(): Future[Boolean] =
+    standingQueryStates.isEmpty().map(!_)(ExecutionContext.parasitic)
 
   override def persistQueryPlan(standingQueryId: StandingQueryId, qp: QueryPlan): Future[Unit] =
     throw new QuinePatternUnimplementedException("Persisting query plans is not supported yet.")

--- a/quine-cassandra-persistor/src/main/scala/com/thatdot/quine/persistor/cassandra/StandingQueryStates.scala
+++ b/quine-cassandra-persistor/src/main/scala/com/thatdot/quine/persistor/cassandra/StandingQueryStates.scala
@@ -54,9 +54,6 @@ class StandingQueryStatesDefinition(namespace: NamespaceId)
       .where(quineIdColumn.is.eq)
       .build()
 
-  private val getStandingQueryStatesCount =
-    select.countAll.build()
-
   private val removeStandingQueryState =
     delete
       .where(
@@ -107,7 +104,6 @@ class StandingQueryStatesDefinition(namespace: NamespaceId)
         _,
         _,
         _,
-        getStandingQueryStatesCount,
         _,
         _,
       ),
@@ -123,7 +119,6 @@ class StandingQueryStates(
   removeStandingQueryStateStatement: PreparedStatement,
   removeStandingQueryStatement: PreparedStatement,
   deleteStandingQueryStatesByQid: PreparedStatement,
-  getStandingQueryStatesCount: SimpleStatement,
   getMultipleValuesStandingQueryStatesStatement: PreparedStatement,
   getIdsForStandingQueryStatement: PreparedStatement,
 )(implicit mat: Materializer)
@@ -170,9 +165,6 @@ class StandingQueryStates(
   def deleteStandingQueryStates(id: QuineId): Future[Unit] = executeFuture(
     deleteStandingQueryStatesByQid.bindColumns(quineIdColumn.set(id)),
   )
-
-  def containsMultipleValuesStates(): Future[Boolean] =
-    queryCount(getStandingQueryStatesCount).map(_ > 0)(ExecutionContext.parasitic)
 
   def removeStandingQuery(standingQuery: StandingQueryId): Future[Unit] =
     executeSource(getIdsForStandingQueryStatement.bindColumns(standingQueryIdColumn.set(standingQuery)))


### PR DESCRIPTION
# Description

COUNT isn't supported on AWS Keyspaces.

Also, the count is just being checked for `> 0`. Counting all items in the table is an inefficient way to check if the table's empty. There's already an existing method for checking if the table's empty, based on seeing if `SELECT quine_id LIMIT 1` returns any results.
Fixes #47 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
