### PR TITLE
Path Support (#2)

### DIFF
--- a/quine/src/main/resources/web/quine-ui.html
+++ b/quine/src/main/resources/web/quine-ui.html
@@ -5,8 +5,8 @@
   <title>Quine</title>
   <meta charset="utf-8">
 
+  <!-- The base href will be updated by the server if path is configured -->
   <base href="/"></base>
-<!-- The base href will be updated by the server if baseUrl is configured -->
 
   <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">

--- a/quine/src/main/resources/web/quine-ui.html
+++ b/quine/src/main/resources/web/quine-ui.html
@@ -6,12 +6,13 @@
   <meta charset="utf-8">
 
   <base href="/"></base>
+<!-- The base href will be updated by the server if baseUrl is configured -->
 
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
+  <link rel="manifest" href="site.webmanifest">
+  <link rel="mask-icon" href="safari-pinned-tab.svg" color="#5bbad5">
   <meta name="msapplication-TileColor" content="#2d89ef">
   <meta name="theme-color" content="#ffffff">
 

--- a/quine/src/main/scala/com/thatdot/quine/app/config/WebServerConfig.scala
+++ b/quine/src/main/scala/com/thatdot/quine/app/config/WebServerConfig.scala
@@ -14,7 +14,7 @@ final case class WebServerBindConfig(
   address: Host = Host("0.0.0.0"),
   port: Port = Port(8080),
   enabled: Boolean = true,
-  useTls: Boolean = sys.env.contains(KeystorePathEnvVar) && sys.env.contains(KeystorePasswordEnvVar),
+  useTls: Boolean = sys.env.contains(KeystorePathEnvVar) && sys.env.contains(KeystorePasswordEnvVar)
 ) {
   def protocol: String = if (useTls) "https" else "http"
 
@@ -41,6 +41,9 @@ object WebServerBindConfig {
 final case class WebserverAdvertiseConfig(
   address: Host,
   port: Port,
+  path: Option[String] = None
 ) {
-  def url(protocol: String): URL = new URL(protocol, address.asString, port.asInt, "")
+  def url(protocol: String): URL = {
+    new URL(protocol, address.asString, port.asInt, path.getOrElse(""))
+  }
 }

--- a/quine/src/main/scala/com/thatdot/quine/app/routes/QuineAppRoutes.scala
+++ b/quine/src/main/scala/com/thatdot/quine/app/routes/QuineAppRoutes.scala
@@ -11,6 +11,8 @@ import org.apache.pekko.http.scaladsl.server.Directives._
 import org.apache.pekko.http.scaladsl.server.{Directives, Route}
 import org.apache.pekko.util.Timeout
 
+import com.thatdot.quine.app.config.QuineConfig
+
 import org.webjars.WebJarAssetLocator
 
 import com.thatdot.common.logging.Log.{LazySafeLogging, LogConfig, SafeLoggableInterpolator}
@@ -76,12 +78,46 @@ class QuineAppRoutes(
     graph.getNamespaces.contains(namespaceFromString(namespace))
 
   /** Serves up the static assets from resources and for JS/CSS dependencies */
+  // Get HTML with possibly modified base href based on configured path
+  private def getHtmlWithBaseHref(): Route = {
+    val pathOpt = config match {
+      case qc: QuineConfig if qc.webserverAdvertise.exists(_.path.isDefined) => 
+        qc.webserverAdvertise.flatMap(_.path)
+      case _ => None
+    }
+    
+    // If path is defined, serve modified HTML, otherwise serve original
+    pathOpt match {
+      case Some(path) =>
+        val baseHref = if (path.isEmpty || path.endsWith("/")) path else path + "/"
+        
+        // Get resource as string
+        val htmlResource = scala.io.Source.fromInputStream(
+          getClass.getResourceAsStream("/web/quine-ui.html")
+        ).mkString
+        
+        // Modify the base href
+        val modifiedHtml = htmlResource.replaceFirst(
+          """<base href=".*?"(.*?)>""", 
+          s"""<base href="$baseHref"$$1>"""
+        )
+        
+        // Serve the modified content
+        import org.apache.pekko.http.scaladsl.model.ContentTypes
+        complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, modifiedHtml))
+        
+      case None =>
+        // Serve the original file without modifications
+        getFromResource("web/quine-ui.html")
+    }
+  }
+
   lazy val staticFilesRoute: Route = {
     Directives.pathEndOrSingleSlash {
-      getFromResource("web/quine-ui.html")
+      getHtmlWithBaseHref()
     } ~
     Directives.path("dashboard" | "docs" | "v2docs") {
-      getFromResource("web/quine-ui.html")
+      getHtmlWithBaseHref()
     } ~
     Directives.path("quine-ui-startup.js") {
       getFromResource("web/quine-ui-startup.js")

--- a/quine/src/test/resources/documented_config.conf
+++ b/quine/src/test/resources/documented_config.conf
@@ -40,6 +40,11 @@ quine {
 
     # port (on `address`) via which the HTTP server can be reached
     # port = 8080
+    
+    # (optional) A path prefix to use when accessing the server. This is useful when Quine 
+    # is running behind a reverse proxy with a subpath.
+    # Example: "/quine"
+    # path = null
   # }
 
   # configuration for the id-assignment scheme the application should use.

--- a/quine/src/test/scala/com/thatdot/quine/app/config/WebServerConfigTest.scala
+++ b/quine/src/test/scala/com/thatdot/quine/app/config/WebServerConfigTest.scala
@@ -1,0 +1,67 @@
+package com.thatdot.quine.app.config
+
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should
+
+import com.thatdot.quine.util.{Host, Port}
+
+class WebServerConfigTest extends AnyFunSuite with should.Matchers {
+  
+  test("WebServerBindConfig should use localhost for wildcard bindings") {
+    val wildcardConfig = WebServerBindConfig(
+      address = Host("0.0.0.0"),
+      port = Port(8080)
+    )
+    
+    val url = wildcardConfig.guessResolvableUrl
+    url.toString should startWith("http://127.0.0.1:8080")
+  }
+  
+  test("WebServerBindConfig should construct URL from host/port") {
+    val config = WebServerBindConfig(
+      address = Host("127.0.0.1"),
+      port = Port(8080)
+    )
+    
+    val url = config.guessResolvableUrl
+    url.toString shouldEqual "http://127.0.0.1:8080"
+  }
+  
+  
+  
+  test("WebserverAdvertiseConfig should use path when provided") {
+    val configWithPath = WebserverAdvertiseConfig(
+      address = Host("example.com"),
+      port = Port(8080),
+      path = Some("/webapp")
+    )
+    
+    val url = configWithPath.url("https")
+    url.toString shouldEqual "https://example.com:8080/webapp"
+  }
+  
+  test("WebserverAdvertiseConfig should construct URL from host/port when path is not provided") {
+    val configWithoutPath = WebserverAdvertiseConfig(
+      address = Host("example.com"),
+      port = Port(8080),
+      path = None
+    )
+    
+    val url = configWithoutPath.url("https")
+    url.toString shouldEqual "https://example.com:8080"
+  }
+  
+  test("WebserverAdvertiseConfig should respect the protocol parameter when path is not provided") {
+    val config = WebserverAdvertiseConfig(
+      address = Host("example.com"),
+      port = Port(8080)
+    )
+    
+    val httpUrl = config.url("http")
+    httpUrl.toString shouldEqual "http://example.com:8080"
+    
+    val httpsUrl = config.url("https")
+    httpsUrl.toString shouldEqual "https://example.com:8080"
+  }
+}


### PR DESCRIPTION
# Description

Added subpath support for Quine web client

This change allows the Quine web client to be hosted at a custom URL subpath by:
  - Adding 'path' option to `WebserverAdvertiseConfig` for specifying URL subpaths
  - Dynamically updating HTML base href tag based on configured path
  - Ensuring static assets use relative paths for compatibility with subpaths
  - Adding test cases to verify path configuration functionality
  - Updating documentation with examples for reverse proxy setup

This feature is especially useful when hosting Quine behind a reverse proxy where it's accessed through a subpath rather than at the domain root.

NOTE: Claude Code was used to generate the changes.

Fixes #46 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Added unit tests under `WebserverConfigTest.scala` 
- [x] Built and deployed JAR to SageMaker Studio JupyterLab instance and could view the exploration UI under `<jupyterlab-instance-domain>/jupyterlab/default/proxy/8080` 
