### PR TITLE
Fix table creation on AWS Keyspaces for keyspaces with upper-case letters.

### DIFF
--- a/quine-cassandra-persistor/src/main/scala/com/thatdot/quine/persistor/cassandra/aws/KeyspacesPersistor.scala
+++ b/quine-cassandra-persistor/src/main/scala/com/thatdot/quine/persistor/cassandra/aws/KeyspacesPersistor.scala
@@ -163,7 +163,7 @@ abstract class AbstractGlobalKeyspacesPersistor[C <: PrimeKeyspacesPersistor](
           val keyspaceExistsQuery = selectFrom("system_schema_mcs", "keyspaces")
             .column("replication")
             .whereColumn("keyspace_name")
-            .isEqualTo(literal(keyspace))
+            .isEqualTo(literal(keyspace.replace("\"", "")))
             .build
           while (!sess.execute(keyspaceExistsQuery).iterator.hasNext) {
             logger.info(safe"Keyspace ${Safe(keyspace)} does not yet exist, re-checking in 4s")


### PR DESCRIPTION
# Description

Fixes #50

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I verified that table creation works in AWS Keyspaces after the change.
