### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val `quine-core`: Project = project
       "org.msgpack" % "msgpack-core" % msgPackV,
       "org.apache.commons" % "commons-text" % commonsTextV,
       "com.github.blemale" %% "scaffeine" % scaffeineV,
-      "io.github.hakky54" % "sslcontext-kickstart" % sslContextKickstartV,
+      "io.github.hakky54" % "ayza" % ayzaV,
       "org.typelevel" %% "cats-core" % catsV,
       "org.typelevel" %% "cats-effect" % catsEffectV,
       "com.thatdot" %% "query-language" % quineQueryV,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -73,7 +73,7 @@ object Dependencies {
   val scoptV = "4.1.0"
   val shapelessV = "2.3.13"
   val slinkyV = "0.7.4"
-  val sslContextKickstartV = "9.0.0"
+  val ayzaV = "10.0.0"
   val stoplightElementsV = "9.0.1"
   val sugarV = "2.0.6"
   val tapirV = "1.11.33"


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to ayza. The latest version is 10.0.0

Sorry for the inconvenience